### PR TITLE
fix number of outputs when loading a flow

### DIFF
--- a/node-red-contrib-snowboy.html
+++ b/node-red-contrib-snowboy.html
@@ -8,13 +8,13 @@
 		},
 		defaults: {
 			name: { value: "" },
+			outputs: { value: "1" },
 			detectorFile: { value: "", required: true },
 			models: { value: [{}], required: true },
 			multipleOutput: { value: "false", required: true},
 			debug: { value: "false" }
 		},
 		inputs: 1,
-		outputs: 1,
 		outputLabels: function(index) {
 			var label = "";
 			for( var i = this.models.length - 1; i >= 0; i-- ) {

--- a/node-red-contrib-snowboy.js
+++ b/node-red-contrib-snowboy.js
@@ -90,6 +90,7 @@ module.exports = function(RED) {
 				}
 				detector.write(msg.payload);
 			} else {
+				if( node.config.debug == true || node.config.debug == "true" )
 				node.error("Error with payload : not a Stream Readable nor a Buffer", msg);
 				return;
 			}


### PR DESCRIPTION
This ensures that the number of outputs is saved in the flow json file so that when it is loaded again the number of outputs is correctly shown in the node.

Regards,
Jaime- 